### PR TITLE
Update download URL for Workspace ONE Intelligent Hub

### DIFF
--- a/VMware/WorkspaceONEIntelligentHub.download.recipe
+++ b/VMware/WorkspaceONEIntelligentHub.download.recipe
@@ -22,7 +22,7 @@
 			<dict>
 				<!-- https://www.getwsone.com/ -->
 				<key>url</key>
-				<string>https://packages.omnissa.com/wsone/WorkspaceONEIntelligentHubRebranded.pkg</string>
+				<string>https://packages.omnissa.com/wsone/HubMacOS.pkg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Updates the URL for the current version of Hub from getwsone.com

Addresses https://github.com/autopkg/hjuutilainen-recipes/issues/324 